### PR TITLE
Fixes wrong icon on parent when a test has failed

### DIFF
--- a/plugin/src/main/webapp/js/testEvents.js
+++ b/plugin/src/main/webapp/js/testEvents.js
@@ -261,6 +261,7 @@ var TestRun = (function($) {
 			this.currentNode.testStatus = TestRun.TestStatus.ERROR;
 			this.currentNode.elapsedTime = 0;
 			this.updateNode(this.currentNode);
+			this.updateParentNode(this.currentNode);
 			this.currentNode.trace = event.trace;
 		},
 		handleTestEndEvent : function(event) {

--- a/plugin/src/main/webapp/js/testEvents.js
+++ b/plugin/src/main/webapp/js/testEvents.js
@@ -302,7 +302,7 @@ var TestRun = (function($) {
 					}
 				}
 				if (childNode.testStatus == TestRun.TestStatus.FAILED
-						|| childNode.testStatus == TestRun.TestStatus.FAILED.ERROR) {
+						|| childNode.testStatus == TestRun.TestStatus.ERROR) {
 					parentTestStatus = TestRun.TestStatus.FAILED;
 				}
 				elapsedTime += childNode.elapsedTime;


### PR DESCRIPTION
Fixes https://issues.jenkins-ci.org/browse/JENKINS-32495
- Update parent node after a test has failed
- Compare `childNode.testStatus` with correct enum value.
